### PR TITLE
Support stable Rust

### DIFF
--- a/howto-cli/Cargo.toml
+++ b/howto-cli/Cargo.toml
@@ -9,9 +9,8 @@ keywords = ["cli", "search"]
 edition = "2018"
 
 [dependencies]
-# rustc 1.39.0-nightly (9eae1fc0e 2019-08-23)
-
-futures-preview = "0.3.0-alpha.18"
+futures-util = { version = "0.3" }
 howto = { version = "0.3", path = "../howto" }
 openssl-probe = "0.1.2"
 structopt = "0.3.0"
+tokio = { version = "0.2", features = ["macros", "rt-threaded"] }

--- a/howto/Cargo.toml
+++ b/howto/Cargo.toml
@@ -9,10 +9,11 @@ keywords = ["cli", "search"]
 edition = "2018"
 
 [dependencies]
-# rustc 1.39.0-nightly (9eae1fc0e 2019-08-23)
-
 failure = "0.1.5"
-futures-preview = "0.3.0-alpha.18"
+futures = "0.3"
 lazy_static = "1.4.0"
+reqwest = "0.10"
 scraper = "0.10.1"
-surf = "1.0.2"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["full"] }

--- a/howto/src/tests.rs
+++ b/howto/src/tests.rs
@@ -1,11 +1,5 @@
-use {
-    crate::{howto, Answer},
-    futures::{
-        executor::{block_on, block_on_stream},
-        prelude::*,
-    },
-    std::thread,
-};
+use crate::{howto, Answer};
+use tokio::stream::StreamExt;
 
 fn print_answer(answer: &Answer) {
     println!(
@@ -15,51 +9,51 @@ fn print_answer(answer: &Answer) {
     println!("{}", answer.instruction);
 }
 
-#[test]
-fn csharp_test() {
-    let answers = block_on_stream(block_on(howto("file io C#")));
+#[tokio::test]
+async fn csharp_test() {
+    let mut answers = howto("file io C#").await;
 
     let mut is_answer_exists = false;
-    for answer in answers {
+    while let Some(answer) = answers.next().await {
         is_answer_exists = true;
         print_answer(&answer);
     }
     assert!(is_answer_exists);
 }
 
-#[test]
-fn cpp_test() {
-    let answers = block_on_stream(block_on(howto("file io C++")));
+#[tokio::test]
+async fn cpp_test() {
+    let mut answers = howto("file io C++").await;
 
     let mut is_answer_exists = false;
-    for answer in answers {
+    while let Some(answer) = answers.next().await {
         is_answer_exists = true;
         print_answer(&answer);
     }
     assert!(is_answer_exists);
 }
 
-#[test]
-fn rust_test() {
-    let answers = block_on_stream(block_on(howto("file io rust")));
+#[tokio::test]
+async fn rust_test() {
+    let mut answers = howto("file io rust").await;
 
     let mut is_answer_exists = false;
-    for answer in answers {
+    while let Some(answer) = answers.next().await {
         is_answer_exists = true;
         print_answer(&answer);
     }
     assert!(is_answer_exists);
 }
 
-#[test]
-fn drop_test() {
-    let mut answers = block_on(howto("file io rust"));
+#[tokio::test]
+async fn drop_test() {
+    let mut answers = howto("file io rust").await;
 
-    let answer = block_on(answers.next()).unwrap();
+    let answer = answers.next().await.unwrap();
     print_answer(&answer);
     drop(answers);
 
     println!("Waiting 10 secs...");
-    thread::sleep(std::time::Duration::from_secs(10));
+    tokio::time::delay_for(std::time::Duration::from_secs(10)).await;
     println!("Success");
 }


### PR DESCRIPTION
This PR upgrades the code to stable Rust, futures to 0.3. It also contains the port from surf to reqwest and from futures-executor to tokio. This provides for much better performance and less dependency on C code.